### PR TITLE
fix(core): Fix ExecuteQuery for cases where cache is already filled

### DIFF
--- a/frontend/src/helpers/data-helpers.ts
+++ b/frontend/src/helpers/data-helpers.ts
@@ -17,12 +17,23 @@ import {QUERIES} from 'src/data/QUERIES';
  * @returns {ApolloQueryResult<Record<string, unknown[]>>} - the query's output
  */
 async function executeQuery(queryObject: QueryObject, variables?: Record<string, unknown>): Promise<ApolloQueryResult<Record<string, unknown[]>>> {
-
   const queryResult = useQuery(queryObject.query, variables ?? {})
 
+  // If we have a cached result, return immediately
+  if(queryResult.result.value){
+    return {
+      data: queryResult.result.value as Record<string, unknown[]>,
+      loading: false,
+    } as ApolloQueryResult<Record<string, unknown[]>>
+  }
+
   return new Promise(((resolve, reject) => {
-    queryResult.onResult((res)=>{resolve(res)})
-    queryResult.onError((err)=>{reject(err)})
+    queryResult.onResult((res)=>{
+      resolve(res)
+    })
+    queryResult.onError((err)=>{
+      reject(err)
+    })
   }))
 }
 


### PR DESCRIPTION
### Before submitting your PR, ensure the following points:
- [x] Your PR goes to the appropriate branch (especially if working on a project)
- [x] Set appropriate labels
- [x] Add descriptive title (not just the branch name)
- [x] Add a short description below
- [x] Your code does not add any ESLint errors (make sure you have **ESLint** enabled!)
- [x] Your code runs locally without any errors
- [x] Your code follows the code conventions in the Wiki

[//]: <> (For the future: **Note:** If you do not check these items, your pull request may be closed automatically.)

### What does your PR change?

Fixes `executeQuery` breaking/not resolving if result is already cached